### PR TITLE
Track download uses new cid cookie name

### DIFF
--- a/MonstercatDownloader.py
+++ b/MonstercatDownloader.py
@@ -76,7 +76,7 @@ def DownloadMonstercatLibrary(sid, output_dir, format="mp3_320", creator_friendl
 						track_id = track['id']
 					),
 					params = {'format': format},
-					cookies = {'connect.sid': sid}
+					cookies = {'cid': sid}
 				)
 
 				with open(full_path, 'wb') as f:


### PR DESCRIPTION
Probably just missed that one while adjusting the other one, it definitely doesn't work with `connect.sid`