### PR TITLE
Add log when download returns a bad status code

### DIFF
--- a/MonstercatDownloader.py
+++ b/MonstercatDownloader.py
@@ -79,6 +79,10 @@ def DownloadMonstercatLibrary(sid, output_dir, format="mp3_320", creator_friendl
 					cookies = {'connect.sid': sid}
 				)
 
+				if mp3.status_code != 200:
+					print('Failed to download {path}, request returned status code {status}. Skipping'.format(path=full_path, status=mp3.status_code))
+					continue
+
 				with open(full_path, 'wb') as f:
 					f.write(mp3.content)
 				downloaded_count += 1


### PR DESCRIPTION
Otherwise it will just save bad files (if you test this without #1 it will skip saving the error message to files)